### PR TITLE
Prevent crashing when chromium loadingFinished and requestIntercepted…

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -149,6 +149,13 @@ class NetworkManager extends EventEmitter {
 
     if (event.redirectUrl) {
       const request = this._interceptionIdToRequest.get(event.interceptionId);
+      //DATASEMBLY CHANGE - It looks like there is a chromium bug where sometimes Network.loadingFinished is unexpectedly
+      //fired before Network.requestIntercepted'. In this case we should log an error instead of crashing via console.assert.
+      //console.assert(request, 'INTERNAL ERROR: failed to find request for interception redirect.');
+      if (!request) {
+        console.error('INTERNAL ERROR: failed to find request for interception redirect.');
+        return;
+      }
       console.assert(request, 'INTERNAL ERROR: failed to find request for interception redirect.');
       this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders);
       this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request);


### PR DESCRIPTION
… event are out of order

It looks like they removed the assert, which could be either a good or bad sign...